### PR TITLE
Update project to godot kotlin jvm `0.10.0-4.3.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This is a small library providing common utilities which might be useful in many
 - [Utilities and their usage](#utilities-and-their-usage)
     - [Autoload](#autoload)
     - [Logging](#logging)
-    - [Coroutine dispatchers](#coroutine-dispatchers)
-    - [Godot coroutine scope](#godot-coroutine-scope)
-    - [Await signals](#await-signals)
-    - [Signal callback connection](#signal-callback-connection)
+    - [[DEPRECATED] Coroutine dispatchers](#coroutine-dispatchers)
+    - [[DEPRECATED] Godot coroutine scope](#godot-coroutine-scope)
+    - [[DEPRECATED] Await signals](#await-signals)
+    - [[DEPRECATED] Signal callback connection](#signal-callback-connection)
 
 ## Adding to your project
 Add the library as a dependency to your project. As it is published to maven central, you should also make sure that you have maven central set up as a repository:
@@ -26,15 +26,6 @@ dependencies {
 
     // if you plan on using the coroutine helpers; don't forget to add the kotlinx coroutines dependency:
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:<version>")
-}
-
-// this project uses context receivers. Until they are readily available in kotlin, you'll need to opt in to be able to use this library!
-tasks {
-  withType<KotlinCompile> {
-    kotlinOptions {
-      this.freeCompilerArgs += "-Xcontext-receivers"
-    }
-  }
 }
 ```
 
@@ -83,7 +74,9 @@ The above examples are present with the following severities:
 - warn
 - err
 
-### Coroutine dispatchers
+### [DEPRECATED] Coroutine dispatchers
+> :warning: **Note:** This functionality is deprecated! Switch to the official [godot-coroutine-library](https://godot-kotl.in/en/stable/user-guide/coroutines/)
+
 Mainly provides a `Dispatchers.Main` and abstracts all dispatcher usage so they are accessed the same:
 
 This library provides an autoload singleton you need to add to your project (remember to have it higher in the order if you use dispatchers in your own autoload singletons, so it's initialised before your autoloads!). You can find the registration file (`gdj`) in the `dependencies` directory in the `gdj` output directory of your project after you've built your project.
@@ -101,7 +94,9 @@ launch(mainDispatcher()) {
 }
 ```
 
-### Godot coroutine scope
+### [DEPRECATED] Godot coroutine scope
+> :warning: **Note:** This functionality is deprecated! Switch to the official [godot-coroutine-library](https://godot-kotl.in/en/stable/user-guide/coroutines/)
+
 Allows you to launch kotlin coroutines from within a node. Iit also provides you the means to run continuations in the context of the node (you can freely choose where, by calling `resumeGodotContinuations`).
 
 **Note:** It is very important that if you use `withGodotContext` you also have a `resumeGodotContinuations` call in your node! Otherwise all coroutines which use `withGodotContext` will block indefinitely and cause memory leaks for good measure! 
@@ -161,7 +156,9 @@ class TestNode : Control(), GodotCoroutineScope by DefaultGodotCoroutineScope() 
 }
 ```
 
-### Await signals
+### [DEPRECATED] Await signals
+> :warning: **Note:** This functionality is deprecated! Switch to the official [godot-coroutine-library](https://godot-kotl.in/en/stable/user-guide/coroutines/)
+
 Allows you to await signal emitions inside coroutines.
 
 > **Note:** Necessitates the setup of [Coroutine dispatchers](#coroutine-dispatchers) and implicitly applies [GodotCoroutineScope](#godot-coroutine-scope)!
@@ -197,7 +194,9 @@ class SignalAwaitSample: Node(), SignalAwaitable by SignalAwaiter() {
 }
 ```
 
-### Signal callback connection
+### [DEPRECATED] Signal callback connection
+> :warning: **Note:** This functionality is deprecated! This functionality is now officially supported.
+
 Allows you to connect to signals using lambdas.
 
 > **Note:** This functionality only exists temporarily until this feature is officially introduced in Godot Kotlin/JVM!  

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-godot.jvm.suppressKotlinIncompatibility=true
+godot.jvm.suppressKotlinIncompatibility=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-godot-kotlin-jvm-utilities = "0.0.4"
-kotlin = "1.9.23"
+godot-kotlin-jvm-utilities = "0.0.5"
+kotlin = "2.0.20"
 jvmToolchainVersion = "17"
 
-godot-kotlin-jvm="0.9.1-4.2.2" # https://github.com/utopia-rise/godot-kotlin-jvm/releases
+godot-kotlin-jvm="0.10.0-4.3.0" # https://github.com/utopia-rise/godot-kotlin-jvm/releases
 
-kotlinx-coroutines-core="1.8.0" # https://github.com/Kotlin/kotlinx.coroutines/releases
-kotlinx-datetime = "0.6.0" # https://github.com/Kotlin/kotlinx-datetime/releases
+kotlinx-coroutines-core="1.9.0" # https://github.com/Kotlin/kotlinx.coroutines/releases
+kotlinx-datetime = "0.6.1" # https://github.com/Kotlin/kotlinx-datetime/releases
 
-maven-publish="0.28.0"
-grgit="5.2.2"
+maven-publish="0.28.0" # https://github.com/vanniktech/gradle-maven-publish-plugin/releases
+grgit="5.2.2" # https://github.com/ajoberstar/grgit/releases
 
 [libraries]
 godot-kotlin-jvm = { group = "com.utopia-rise", name = "godot-library-release", version.ref = "godot-kotlin-jvm" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+# https://gradle.org/releases/
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/src/main/kotlin/sample/coroutines/await/SignalAwaitSample.kt
+++ b/sample/src/main/kotlin/sample/coroutines/await/SignalAwaitSample.kt
@@ -6,8 +6,9 @@ import godot.Node
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
+import godot.core.signal0
+import godot.core.signal1
 import godot.global.GD
-import godot.signals.signal
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -15,8 +16,8 @@ import kotlin.time.Duration.Companion.seconds
 
 @RegisterClass
 class SignalAwaitSample: Node(), SignalAwaitable by SignalAwaiter() {
-    @RegisterSignal val customSignalWithArgs by signal<String>("someData")
-    @RegisterSignal val customSignalForMultiAwaitTest by signal()
+    @RegisterSignal val customSignalWithArgs by signal1<String>("someData")
+    @RegisterSignal val customSignalForMultiAwaitTest by signal0()
 
     init {
         initSignalAwait()

--- a/sample/src/main/kotlin/sample/signal/SignalConnectorSample.kt
+++ b/sample/src/main/kotlin/sample/signal/SignalConnectorSample.kt
@@ -7,13 +7,13 @@ import godot.Object
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
+import godot.core.signal1
 import godot.global.GD
-import godot.signals.signal
 
 @RegisterClass
 class SignalConnectorSample : Node(), SignalConnectable by SignalConnector() {
     @RegisterSignal
-    val customSignalWithArgs by signal<String>("someData")
+    val customSignalWithArgs by signal1<String>("someData")
 
     init {
         initSignalConnectable()

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/DispatcherSingleton.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/DispatcherSingleton.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.ContinuationInterceptor
 
 @RegisterClass
+@Deprecated(message = "This is no longer supported! Use awaitDeferred from godot-coroutine-library to run code on the ui thread instead!")
 class DispatcherSingleton: Node() {
     companion object {
         var mainDispatcher: CoroutineDispatcher? = null

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/await/SignalAwaitable.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/await/SignalAwaitable.kt
@@ -3,11 +3,14 @@ package ch.hippmann.godot.utilities.coroutines.await
 import ch.hippmann.godot.utilities.coroutines.scope.GodotCoroutineScope
 import godot.Node
 import godot.annotation.RegisterFunction
-import godot.signals.Signal
+import godot.core.Signal
 
+@Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
 interface SignalAwaitable: GodotCoroutineScope {
+    @Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
     fun <T: Node> T.initSignalAwait()
 
+    @Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
     suspend fun Signal.await(): Array<Any?>
 
     @RegisterFunction

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/await/SignalAwaiter.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/await/SignalAwaiter.kt
@@ -8,19 +8,19 @@ import godot.Node
 import godot.OS
 import godot.Object
 import godot.core.Callable
+import godot.core.NativeCallable
+import godot.core.Signal
+import godot.core.Signal0
+import godot.core.Signal1
+import godot.core.Signal2
+import godot.core.Signal3
+import godot.core.Signal4
+import godot.core.Signal5
+import godot.core.Signal6
+import godot.core.Signal7
+import godot.core.Signal8
 import godot.core.StringName
-import godot.core.asStringName
-import godot.signals.Signal
-import godot.signals.Signal0
-import godot.signals.Signal1
-import godot.signals.Signal2
-import godot.signals.Signal3
-import godot.signals.Signal4
-import godot.signals.Signal5
-import godot.signals.Signal6
-import godot.signals.Signal7
-import godot.signals.Signal8
-import godot.util.camelToSnakeCase
+import godot.core.toGodotName
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -32,23 +32,25 @@ import kotlin.coroutines.suspendCoroutine
 
 private data class AwaitDataContainer(
     val continuation: Continuation<Array<Any?>>,
-    val callable: Callable,
+    val callable: NativeCallable,
     val signalName: StringName,
 ) {
-    fun assembleKey(owner: Node): String = "${owner.id}_${signalName}_${callable.getMethod()}"
+    fun assembleKey(owner: Node): String = "${owner.objectID}_${signalName}_${callable.getMethod()}"
 }
 
 @Suppress("unused")
+@Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
 class SignalAwaiter(
     private val printDebug: Boolean = OS.isDebugBuild(),
 ) : SignalAwaitable, GodotCoroutineScope by DefaultGodotCoroutineScope() {
     private var owner: WeakReference<Node>? = null
 
+    @Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
     override fun <T : Node> T.initSignalAwait() {
         this@SignalAwaiter.owner = WeakReference(this)
         val callable = Callable(
             target = this,
-            methodName = ::signalAwaitableTriggerContinuations.name.camelToSnakeCase().asStringName(),
+            methodName = ::signalAwaitableTriggerContinuations.name.toGodotName(),
         )
         this.treeEntered.connect(callable)
         this.ready.connect(callable)
@@ -59,6 +61,7 @@ class SignalAwaiter(
     private val continuationMapLock = Mutex()
     private val continuationMap: MutableMap<String, List<AwaitDataContainer>> = mutableMapOf()
 
+    @Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
     override suspend fun Signal.await(): Array<Any?> {
         val owner = this@SignalAwaiter.owner?.get() ?: run {
             if (OS.isDebugBuild()) {
@@ -121,7 +124,7 @@ class SignalAwaiter(
         }
     }
 
-    private fun Signal.provideCallable(owner: Node, signalName: String): Callable {
+    private fun Signal.provideCallable(owner: Node, signalName: String): NativeCallable {
         val function = when (this) {
             is Signal0 -> ::signalAwaitableSignalCallback0Args
             is Signal1<*> -> ::signalAwaitableSignalCallback1Args
@@ -136,7 +139,7 @@ class SignalAwaiter(
         }
         return Callable(
             target = owner,
-            methodName = function.name.camelToSnakeCase().asStringName()
+            methodName = function.name.toGodotName()
         ).bind(signalName)
     }
 
@@ -174,14 +177,14 @@ class SignalAwaiter(
     }
 
     private fun assembleKey(owner: Node, signalName: String, callableName: String) =
-        "${owner.id}_${signalName}_${callableName}"
+        "${owner.objectID}_${signalName}_${callableName}"
 
     // START: await callback registered functions
     override fun signalAwaitableSignalCallback0Args(signalName: String) {
         signalAwaitableSignalCallback(
             args = arrayOf(),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback0Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback0Args.name.toGodotName().toString(),
         )
     }
 
@@ -189,7 +192,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback1Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback1Args.name.toGodotName().toString(),
         )
     }
 
@@ -197,7 +200,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback2Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback2Args.name.toGodotName().toString(),
         )
     }
 
@@ -205,7 +208,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1, arg2),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback3Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback3Args.name.toGodotName().toString(),
         )
     }
 
@@ -219,7 +222,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1, arg2, arg3),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback4Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback4Args.name.toGodotName().toString(),
         )
     }
 
@@ -234,7 +237,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1, arg2, arg3, arg4),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback5Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback5Args.name.toGodotName().toString(),
         )
     }
 
@@ -250,7 +253,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1, arg2, arg3, arg4, arg5),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback6Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback6Args.name.toGodotName().toString(),
         )
     }
 
@@ -267,7 +270,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback7Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback7Args.name.toGodotName().toString(),
         )
     }
 
@@ -285,7 +288,7 @@ class SignalAwaiter(
         signalAwaitableSignalCallback(
             args = arrayOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
             signalName = signalName,
-            callableName = ::signalAwaitableSignalCallback8Args.name.camelToSnakeCase(),
+            callableName = ::signalAwaitableSignalCallback8Args.name.toGodotName().toString(),
         )
     }
 

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/dispatchers.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/dispatchers.kt
@@ -3,10 +3,15 @@ package ch.hippmann.godot.utilities.coroutines
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
+@Deprecated(message = "This is no longer supported! Use awaitDeferred from godot-coroutine-library to run code on the ui thread instead!")
 fun mainDispatcher(): CoroutineDispatcher = requireNotNull(DispatcherSingleton.mainDispatcher) {
     "${DispatcherSingleton.Companion::mainDispatcher.name} is null! Did you forget to add the ${DispatcherSingleton::class.java.simpleName} singleton to the autoload singletons in the godot project settings?"
 }
 
+
+@Deprecated(message = "Coroutine related helpers are being removed in favour of godot-coroutine-library! Copy this helper to your project if you need it")
 fun ioDispatcher() = Dispatchers.IO
 
+
+@Deprecated(message = "Coroutine related helpers are being removed in favour of godot-coroutine-library! Copy this helper to your project if you need it")
 fun defaultDispatcher() = Dispatchers.Default

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/scope/DefaultGodotCoroutineScope.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/scope/DefaultGodotCoroutineScope.kt
@@ -12,6 +12,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.suspendCoroutine
 
 @Suppress("unused")
+@Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
 class DefaultGodotCoroutineScope : GodotCoroutineScope {
     private val godotContinuationsMutex = Mutex()
     private val godotContinuations: Queue<GodotContinuationWithBlock> = LinkedList()
@@ -30,6 +31,7 @@ class DefaultGodotCoroutineScope : GodotCoroutineScope {
         }
     }
 
+    @Deprecated(message = "This is no longer supported! Use awaitDeferred from godot-coroutine-library instead!")
     override fun Node.resumeGodotContinuations() {
         runBlocking {
             godotContinuationsMutex.withLock {
@@ -42,6 +44,7 @@ class DefaultGodotCoroutineScope : GodotCoroutineScope {
         }
     }
 
+    @Deprecated(message = "This is no longer supported! Use awaitDeferred from godot-coroutine-library instead!")
     override suspend fun Node.withGodotContext(block: () -> Unit) {
         suspendCoroutine { continuation ->
             runBlocking {

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/scope/GodotCoroutineScope.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/coroutines/scope/GodotCoroutineScope.kt
@@ -5,8 +5,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
+@Deprecated(message = "This functionality is now part of the official godot-coroutine-library! See: https://godot-kotl.in/en/stable/user-guide/coroutines/")
 interface GodotCoroutineScope : CoroutineScope {
+    @Deprecated(message = "This is no longer supported! Use awaitDeferred from godot-coroutine-library instead!")
     fun Node.resumeGodotContinuations()
+
+    @Deprecated(message = "This is no longer supported! Use awaitDeferred from godot-coroutine-library instead!")
     suspend fun Node.withGodotContext(block: () -> Unit)
 }
 

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/logging/logging.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/logging/logging.kt
@@ -2,13 +2,9 @@ package ch.hippmann.godot.utilities.logging
 
 import ch.hippmann.godot.utilities.datetime.localNow
 import ch.hippmann.godot.utilities.logging.Log.peerIdForLogging
-import godot.OS
 import godot.global.GD
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.char
-
-@PublishedApi
-internal val isDebugBuild by lazy { OS.isDebugBuild() }
 
 enum class LogLevel {
     TRACE,
@@ -20,12 +16,6 @@ enum class LogLevel {
 
 object Log {
     var peerIdForLogging: Int? = null
-
-    var logLevel: LogLevel = if (OS.isDebugBuild()) {
-        LogLevel.DEBUG
-    } else {
-        LogLevel.INFO
-    }
 
     context(T) inline fun <reified T> trace(t: Throwable? = null, message: () -> String) = trace(message(), t)
     context(T) inline fun <reified T> trace(message: String, t: Throwable? = null) = __log<T>(LogLevel.TRACE, message, t)
@@ -77,7 +67,7 @@ internal inline fun <reified T> __log(level: LogLevel, message: String, t: Throw
 
     when(level) {
         LogLevel.ERROR -> GD.printErr(formattedMessage)
-        LogLevel.WARN -> GD.print(formattedMessage)
+        LogLevel.WARN -> GD.pushWarning(formattedMessage)
         LogLevel.INFO -> GD.print(formattedMessage)
         LogLevel.DEBUG -> GD.print(formattedMessage)
         LogLevel.TRACE -> GD.print(formattedMessage)

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/signal/SignalConnectable.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/signal/SignalConnectable.kt
@@ -1,75 +1,86 @@
 package ch.hippmann.godot.utilities.signal
 
+import godot.Error
 import godot.Node
 import godot.annotation.RegisterFunction
-import godot.core.GodotError
+import godot.core.Signal0
+import godot.core.Signal1
+import godot.core.Signal2
+import godot.core.Signal3
+import godot.core.Signal4
+import godot.core.Signal5
+import godot.core.Signal6
+import godot.core.Signal7
+import godot.core.Signal8
 import godot.core.VariantArray
-import godot.signals.Signal0
-import godot.signals.Signal1
-import godot.signals.Signal2
-import godot.signals.Signal3
-import godot.signals.Signal4
-import godot.signals.Signal5
-import godot.signals.Signal6
-import godot.signals.Signal7
-import godot.signals.Signal8
 
+@Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
 interface SignalConnectable {
     sealed interface ConnectionResult {
         data class Success(val signalHandle: String): ConnectionResult
-        data class Failure(val godotError: GodotError): ConnectionResult
+        data class Failure(val godotError: Error): ConnectionResult
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <T : Node> T.initSignalConnectable()
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun Signal0.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: () -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0> Signal1<P0>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1> Signal2<P0, P1>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0, P1) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1, P2> Signal3<P0, P1, P2>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0, P1, P2) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1, P2, P3> Signal4<P0, P1, P2, P3>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0, P1, P2, P3) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1, P2, P3, P4> Signal5<P0, P1, P2, P3, P4>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0, P1, P2, P3, P4) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1, P2, P3, P4, P5> Signal6<P0, P1, P2, P3, P4, P5>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0, P1, P2, P3, P4, P5) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1, P2, P3, P4, P5, P6> Signal7<P0, P1, P2, P3, P4, P5, P6>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,
         callback: (P0, P1, P2, P3, P4, P5, P6) -> Unit,
     ): ConnectionResult
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     fun <P0, P1, P2, P3, P4, P5, P6, P7> Signal8<P0, P1, P2, P3, P4, P5, P6, P7>.connect(
         flags: Long = 0,
         binds: VariantArray<Any?>? = null,

--- a/utilities/src/main/kotlin/ch/hippmann/godot/utilities/signal/SignalConnector.kt
+++ b/utilities/src/main/kotlin/ch/hippmann/godot/utilities/signal/SignalConnector.kt
@@ -1,21 +1,21 @@
 package ch.hippmann.godot.utilities.signal
 
+import godot.Error
 import godot.Node
 import godot.core.Callable
-import godot.core.GodotError
+import godot.core.Signal
+import godot.core.Signal0
+import godot.core.Signal1
+import godot.core.Signal2
+import godot.core.Signal3
+import godot.core.Signal4
+import godot.core.Signal5
+import godot.core.Signal6
+import godot.core.Signal7
+import godot.core.Signal8
 import godot.core.VariantArray
 import godot.core.asStringName
-import godot.signals.Signal
-import godot.signals.Signal0
-import godot.signals.Signal1
-import godot.signals.Signal2
-import godot.signals.Signal3
-import godot.signals.Signal4
-import godot.signals.Signal5
-import godot.signals.Signal6
-import godot.signals.Signal7
-import godot.signals.Signal8
-import godot.util.camelToSnakeCase
+import godot.core.toGodotName
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -23,11 +23,13 @@ import java.lang.ref.WeakReference
 import java.util.*
 
 @Suppress("unused")
+@Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
 class SignalConnector : SignalConnectable {
     private val callbackMapLock = Mutex()
     private val callbackMap = mutableMapOf<String, MutableMap<String, (List<Any?>) -> Unit>>()
     private var owner: WeakReference<Node>? = null
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <T : Node> T.initSignalConnectable() {
         this@SignalConnector.owner = WeakReference(this)
     }
@@ -62,7 +64,7 @@ class SignalConnector : SignalConnectable {
             flags = flags.toInt(),
         )
 
-        if (connectionResult == GodotError.OK) {
+        if (connectionResult == Error.OK) {
             val callbackId = runBlocking {
                 callbackMapLock.withLock {
                     val callbackData = callbackMap[signalName] ?: mutableMapOf()
@@ -131,7 +133,7 @@ class SignalConnector : SignalConnectable {
         }
         return Callable(
             target = owner,
-            methodName = function.name.camelToSnakeCase().asStringName()
+            methodName = function.name.toGodotName()
         )
     }
 
@@ -161,6 +163,7 @@ class SignalConnector : SignalConnectable {
         disconnect(provideCallable())
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun Signal0.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -168,7 +171,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback0Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback0Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { _ ->
@@ -176,6 +179,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0> Signal1<P0>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -183,7 +187,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -192,6 +196,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1> Signal2<P0, P1>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -199,7 +204,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -211,6 +216,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1, P2> Signal3<P0, P1, P2>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -218,7 +224,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -231,6 +237,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1, P2, P3> Signal4<P0, P1, P2, P3>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -238,7 +245,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -252,6 +259,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1, P2, P3, P4> Signal5<P0, P1, P2, P3, P4>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -259,7 +267,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -274,6 +282,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1, P2, P3, P4, P5> Signal6<P0, P1, P2, P3, P4, P5>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -281,7 +290,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -297,6 +306,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1, P2, P3, P4, P5, P6> Signal7<P0, P1, P2, P3, P4, P5, P6>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -304,7 +314,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->
@@ -321,6 +331,7 @@ class SignalConnector : SignalConnectable {
         }
     }
 
+    @Deprecated(message = "This functionality is now part of the official godot-library! Use the signals connect function with the lambda syntax instead! If however you depend on the ability to disconnect these lambdas again, you can keep using these helpers. They will only be removed once this feature is supported officially in godot-kotlin!")
     override fun <P0, P1, P2, P3, P4, P5, P6, P7> Signal8<P0, P1, P2, P3, P4, P5, P6, P7>.connect(
         flags: Long,
         binds: VariantArray<Any?>?,
@@ -328,7 +339,7 @@ class SignalConnector : SignalConnectable {
     ): SignalConnectable.ConnectionResult {
         return connectInternal(
             signal = this,
-            methodName = ::signalConnectableSignalCallback1Args.name.camelToSnakeCase(),
+            methodName = ::signalConnectableSignalCallback1Args.name.toGodotName().toString(),
             binds = binds,
             flags = flags,
         ) { args ->


### PR DESCRIPTION
Thus this deprecated all signal and coroutine related helpers as they are now part of the official project